### PR TITLE
Add more input validation

### DIFF
--- a/aurora_echo/echo_new.py
+++ b/aurora_echo/echo_new.py
@@ -29,7 +29,7 @@ import boto3
 import click
 
 from aurora_echo.echo_const import ECHO_NEW_STAGE, ECHO_NEW_COMMAND
-from aurora_echo.echo_util import EchoUtil, log_prefix_factory
+from aurora_echo.echo_util import EchoUtil, log_prefix_factory, validate_input_param
 from aurora_echo.entry import root
 
 rds = boto3.client('rds')
@@ -132,12 +132,12 @@ def create_cluster_and_instance(cluster_params: dict, instance_params: dict, int
 
 
 @root.command()
-@click.option('--aws-account-number', '-a', required=True)
-@click.option('--region', '-r', required=True)
-@click.option('--cluster-snapshot-name', '-s', required=True)
-@click.option('--managed-name', '-n', required=True)
-@click.option('--db-subnet-group-name', '-sub', required=True)
-@click.option('--db-instance-class', '-c', required=True)
+@click.option('--aws-account-number', '-a', callback=validate_input_param, required=True)
+@click.option('--region', '-r', callback=validate_input_param, required=True)
+@click.option('--cluster-snapshot-name', '-s', callback=validate_input_param, required=True)
+@click.option('--managed-name', '-n', callback=validate_input_param, required=True)
+@click.option('--db-subnet-group-name', '-sub', callback=validate_input_param, required=True)
+@click.option('--db-instance-class', '-c', callback=validate_input_param, required=True)
 @click.option('--engine', '-e', default='aurora')
 @click.option('--availability-zone', '-az')
 @click.option('--vpc-security-group-id', '-sg', multiple=True)

--- a/aurora_echo/echo_promote.py
+++ b/aurora_echo/echo_promote.py
@@ -28,7 +28,7 @@ import boto3
 import click
 
 from aurora_echo.echo_const import ECHO_NEW_STAGE, ECHO_PROMOTE_COMMAND, ECHO_PROMOTE_STAGE, ECHO_RETIRE_STAGE
-from aurora_echo.echo_util import EchoUtil, log_prefix_factory
+from aurora_echo.echo_util import EchoUtil, log_prefix_factory, validate_input_param
 from aurora_echo.entry import root
 
 rds = boto3.client('rds')
@@ -88,11 +88,11 @@ def update_dns(hosted_zone_id: str, record_set: dict, cluster_endpoint: str, ttl
 
 
 @root.command()
-@click.option('--aws-account-number', '-a', required=True)
-@click.option('--region', '-r', required=True)
-@click.option('--managed-name', '-n', required=True)
-@click.option('--hosted-zone-id', '-z', required=True)
-@click.option('--record-set', '-rs', required=True)
+@click.option('--aws-account-number', '-a', callback=validate_input_param, required=True)
+@click.option('--region', '-r', callback=validate_input_param, required=True)
+@click.option('--managed-name', '-n', callback=validate_input_param, required=True)
+@click.option('--hosted-zone-id', '-z', callback=validate_input_param, required=True)
+@click.option('--record-set', '-rs', callback=validate_input_param, required=True)
 @click.option('--ttl', default=60)
 @click.option('--interactive', '-i', default=True, type=bool)
 def promote(aws_account_number: str, region: str, managed_name: str, hosted_zone_id: str, record_set: str, ttl: str,

--- a/aurora_echo/echo_retire.py
+++ b/aurora_echo/echo_retire.py
@@ -28,7 +28,7 @@ import boto3
 import click
 
 from aurora_echo.echo_const import ECHO_RETIRE_COMMAND, ECHO_RETIRE_STAGE
-from aurora_echo.echo_util import EchoUtil, log_prefix_factory
+from aurora_echo.echo_util import EchoUtil, log_prefix_factory, validate_input_param
 from aurora_echo.entry import root
 
 rds = boto3.client('rds')
@@ -63,9 +63,9 @@ def delete_instance(instance: dict, interactive: bool):
 
 
 @root.command()
-@click.option('--aws-account-number', '-a', required=True)
-@click.option('--region', '-r', required=True)
-@click.option('--managed-name', '-n', required=True)
+@click.option('--aws-account-number', '-a', callback=validate_input_param, required=True)
+@click.option('--region', '-r', callback=validate_input_param, required=True)
+@click.option('--managed-name', '-n', callback=validate_input_param, required=True)
 @click.option('--interactive', '-i', default=True, type=bool)
 def retire(aws_account_number: str, region: str, managed_name: str, interactive: bool):
     click.echo('{} Starting aurora-echo for {}'.format(log_prefix(), managed_name))


### PR DESCRIPTION
- Check for non-empty input strings using click's callback method
- Try/except around tag listing to warn the user about bad account or region inputs. Previously bad account info would throw an exception when the ARN lookup attempt failed, so now we can show a nice message to the user.

Sample output: :boom: 

``` sh
$ build/aurora-echo retire -a '' -r '' -n ''
Usage: aurora-echo retire [OPTIONS]

Error: Invalid value for "--aws-account-number" / "-a": parameter must not be empty
```

``` sh
$ build/aurora-echo new -a 123 -r a -s nope -n wat -sub wat -c lala
2016-10-17 21:22:24 UTC+00:00 [new] Starting aurora-echo for wat
Usage: aurora-echo new [OPTIONS]

Error: Unable to list tags for resource at 'arn:aws:rds:a:123:db:<snip>'. Check your account number and region and try again.
```
