### PR TITLE
Multiple hosted zones

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ sudo chmod +x /usr/local/bin/aurora-echo
 - `-n, --managed-name [required]`
   - The managed name tracking the instance you want to promote. This is the same as the `--managed-name` parameter used in the `new` step.
 - `-z, --hosted-zone-id [required]`
-  - The ID of the hosted zone containing the DNS record set to be updated
+  - The ID of the hosted zone containing the DNS record set to be updated. You can give this option multiple times to add the same record set in multiple hosted zones.
 - `-rs, --record-set [required]`
   - Name of the record set to update, e.g. `dev-db.mycompany.com`. Aurora Echo only supports CNAME updates.
 - `--ttl`

--- a/aurora_echo/echo_promote.py
+++ b/aurora_echo/echo_promote.py
@@ -48,57 +48,58 @@ def find_record_set(hosted_zone_id: str, record_set_name: str):
                 return record_set
 
 
-def update_dns(hosted_zone_id: str, record_set_name: str, cluster_endpoint: str, ttl: str, interactive: bool):
-    record_set = find_record_set(hosted_zone_id, record_set_name)
+def update_dns(hosted_zone_ids: tuple, record_set_name: str, cluster_endpoint: str, ttl: str, interactive: bool):
+    for hosted_zone in hosted_zone_ids:
+        record_set = find_record_set(hosted_zone, record_set_name)
 
-    if record_set and record_set.get('ResourceRecords'):
-        click.echo('{} Found record set {} currently pointed at {}'
-                   .format(log_prefix(), record_set['Name'], record_set['ResourceRecords'][0]['Value']))
-    else:
-        click.echo('{} Inserting new record set {}'.format(log_prefix(), record_set_name))
+        if record_set and record_set.get('ResourceRecords'):
+            click.echo('{} Found record set {} currently pointed at {}'
+                       .format(log_prefix(), record_set['Name'], record_set['ResourceRecords'][0]['Value']))
+        else:
+            click.echo('{} Inserting new record set {} in hosted zone {}'.format(log_prefix(), record_set_name, hosted_zone))
 
-    params = {
-        'HostedZoneId': hosted_zone_id,
-        'ChangeBatch': {
-            'Comment': 'Modified by Aurora Echo',
-            'Changes': [
-                {
-                    'Action': 'UPSERT',
-                    'ResourceRecordSet': {
-                        'Name': record_set_name,
-                        'Type': 'CNAME',
-                        'TTL': ttl,
-                        'ResourceRecords': [
-                            {
-                                'Value': cluster_endpoint
-                            },
-                        ],
-                    }
-                },
-            ]
+        params = {
+            'HostedZoneId': hosted_zone,
+            'ChangeBatch': {
+                'Comment': 'Modified by Aurora Echo',
+                'Changes': [
+                    {
+                        'Action': 'UPSERT',
+                        'ResourceRecordSet': {
+                            'Name': record_set_name,
+                            'Type': 'CNAME',
+                            'TTL': ttl,
+                            'ResourceRecords': [
+                                {
+                                    'Value': cluster_endpoint
+                                },
+                            ],
+                        }
+                    },
+                ]
+            }
         }
-    }
 
-    click.echo('{} Parameters:'.format(log_prefix()))
-    click.echo(json.dumps(params, indent=4, sort_keys=True))
+        click.echo('{} Parameters:'.format(log_prefix()))
+        click.echo(json.dumps(params, indent=4, sort_keys=True))
 
-    if interactive:
-        click.confirm('{} Ready to update DNS record with these settings?'.format(log_prefix()), abort=True)  # exits entirely if no
+        if interactive:
+            click.confirm('{} Ready to update DNS record with these settings?'.format(log_prefix()), abort=True)  # exits entirely if no
 
-    # update to the found instance endpoint
-    response = route53.change_resource_record_sets(**params)
-    click.echo('{} Success! DNS updated.'.format(log_prefix()))
+        # update to the found instance endpoint
+        response = route53.change_resource_record_sets(**params)
+        click.echo('{} Success! DNS updated in hosted zone {}'.format(log_prefix(), hosted_zone))
 
 
 @root.command()
 @click.option('--aws-account-number', '-a', callback=validate_input_param, required=True)
 @click.option('--region', '-r', callback=validate_input_param, required=True)
 @click.option('--managed-name', '-n', callback=validate_input_param, required=True)
-@click.option('--hosted-zone-id', '-z', callback=validate_input_param, required=True)
+@click.option('--hosted-zone-id', '-z', callback=validate_input_param, multiple=True, required=True)
 @click.option('--record-set', '-rs', callback=validate_input_param, required=True)
 @click.option('--ttl', default=60)
 @click.option('--interactive', '-i', default=True, type=bool)
-def promote(aws_account_number: str, region: str, managed_name: str, hosted_zone_id: str, record_set: str, ttl: str,
+def promote(aws_account_number: str, region: str, managed_name: str, hosted_zone_id: tuple, record_set: str, ttl: str,
             interactive: bool):
     click.echo('{} Starting aurora-echo for {}'.format(log_prefix(), managed_name))
     util = EchoUtil(region, aws_account_number)

--- a/aurora_echo/echo_promote.py
+++ b/aurora_echo/echo_promote.py
@@ -104,12 +104,15 @@ def promote(aws_account_number: str, region: str, managed_name: str, hosted_zone
     click.echo('{} Starting aurora-echo for {}'.format(log_prefix(), managed_name))
     util = EchoUtil(region, aws_account_number)
 
+    # click doesn't allow mismatches between option and parameter names, so just for clarity, this is a tuple
+    hosted_zone_ids = hosted_zone_id
+
     found_instance = util.find_instance_in_stage(managed_name, ECHO_NEW_STAGE)
     if found_instance and found_instance['DBInstanceStatus'] == 'available':
         click.echo('{} Found promotable instance: {}'.format(log_prefix(), found_instance['DBInstanceIdentifier']))
         cluster_endpoint = found_instance['Endpoint']['Address']
 
-        update_dns(hosted_zone_id, record_set, cluster_endpoint, ttl, interactive)
+        update_dns(hosted_zone_ids, record_set, cluster_endpoint, ttl, interactive)
 
         old_promoted_instance = util.find_instance_in_stage(managed_name, ECHO_PROMOTE_STAGE)
         if old_promoted_instance:

--- a/aurora_echo/echo_promote.py
+++ b/aurora_echo/echo_promote.py
@@ -39,12 +39,13 @@ log_prefix = log_prefix_factory(ECHO_PROMOTE_COMMAND)
 
 def find_record_set(hosted_zone_id: str, record_set_name: str):
 
-    response = route53.list_resource_record_sets(HostedZoneId=hosted_zone_id)
-    record_sets_list = response['ResourceRecordSets']
+    paginator = route53.get_paginator('list_resource_record_sets')
+    response_iterator = paginator.paginate(HostedZoneId=hosted_zone_id)
 
-    for record_set in record_sets_list:
-        if record_set['Name'] == record_set_name:
-            return record_set
+    for response in response_iterator:
+        for record_set in response['ResourceRecordSets']:
+            if record_set['Name'] == record_set_name:
+                return record_set
 
 
 def update_dns(hosted_zone_id: str, record_set_name: str, cluster_endpoint: str, ttl: str, interactive: bool):

--- a/aurora_echo/echo_promote.py
+++ b/aurora_echo/echo_promote.py
@@ -47,12 +47,14 @@ def find_record_set(hosted_zone_id: str, record_set_name: str):
             return record_set
 
 
-def update_dns(hosted_zone_id: str, record_set: dict, cluster_endpoint: str, ttl: str, interactive: bool):
-    # print out the record we're replacing
-    currently_set_endpoint = 'nothing'
-    if record_set.get('ResourceRecords'):
-        currently_set_endpoint = record_set['ResourceRecords'][0]['Value']
-    click.echo('{} Found record set {} currently pointed at {}'.format(log_prefix(), record_set['Name'], currently_set_endpoint))
+def update_dns(hosted_zone_id: str, record_set_name: str, cluster_endpoint: str, ttl: str, interactive: bool):
+    record_set = find_record_set(hosted_zone_id, record_set_name)
+
+    if record_set and record_set.get('ResourceRecords'):
+        click.echo('{} Found record set {} currently pointed at {}'
+                   .format(log_prefix(), record_set['Name'], record_set['ResourceRecords'][0]['Value']))
+    else:
+        click.echo('{} Inserting new record set {}'.format(log_prefix(), record_set_name))
 
     params = {
         'HostedZoneId': hosted_zone_id,
@@ -62,8 +64,8 @@ def update_dns(hosted_zone_id: str, record_set: dict, cluster_endpoint: str, ttl
                 {
                     'Action': 'UPSERT',
                     'ResourceRecordSet': {
-                        'Name': record_set['Name'],
-                        'Type': record_set['Type'],
+                        'Name': record_set_name,
+                        'Type': 'CNAME',
                         'TTL': ttl,
                         'ResourceRecords': [
                             {
@@ -105,20 +107,16 @@ def promote(aws_account_number: str, region: str, managed_name: str, hosted_zone
         click.echo('{} Found promotable instance: {}'.format(log_prefix(), found_instance['DBInstanceIdentifier']))
         cluster_endpoint = found_instance['Endpoint']['Address']
 
-        record_set_dict = find_record_set(hosted_zone_id, record_set)
-        if record_set_dict:
-            update_dns(hosted_zone_id, record_set_dict, cluster_endpoint, ttl, interactive)
+        update_dns(hosted_zone_id, record_set, cluster_endpoint, ttl, interactive)
 
-            old_promoted_instance = util.find_instance_in_stage(managed_name, ECHO_PROMOTE_STAGE)
-            if old_promoted_instance:
-                click.echo('{} Retiring old instance: {}'.format(log_prefix(), old_promoted_instance['DBInstanceIdentifier']))
-                util.add_stage_tag(managed_name, old_promoted_instance, ECHO_RETIRE_STAGE)
+        old_promoted_instance = util.find_instance_in_stage(managed_name, ECHO_PROMOTE_STAGE)
+        if old_promoted_instance:
+            click.echo('{} Retiring old instance: {}'.format(log_prefix(), old_promoted_instance['DBInstanceIdentifier']))
+            util.add_stage_tag(managed_name, old_promoted_instance, ECHO_RETIRE_STAGE)
 
-            click.echo('{} Updating tag for promoted instance: {}'.format(log_prefix(), found_instance['DBInstanceIdentifier']))
-            util.add_stage_tag(managed_name, found_instance, ECHO_PROMOTE_STAGE)
+        click.echo('{} Updating tag for promoted instance: {}'.format(log_prefix(), found_instance['DBInstanceIdentifier']))
+        util.add_stage_tag(managed_name, found_instance, ECHO_PROMOTE_STAGE)
 
-            click.echo('{} Done!'.format(log_prefix()))
-        else:
-            click.echo('{} No record set found at hosted zone {} with name {}. Unable to promote instance.'.format(log_prefix(), hosted_zone_id, record_set))
+        click.echo('{} Done!'.format(log_prefix()))
     else:
         click.echo('{} No instance found in stage {} with status \'available\'. Not proceeding.'.format(log_prefix(), ECHO_NEW_STAGE))


### PR DESCRIPTION
- Paginate through record sets in a hosted zone. `list_resource_record_sets` previously only returned 100 records.
- Allow insertion of new record sets, removing the useless requirement that it already had to exist
- Allow multiple hosted zones such that the same record set can be upserted in all of them

This has been tested. :taco: :cat: 