### PR TITLE
Linting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,12 @@
 PYTHON_MAIN=aurora_echo/__init__.py
 FINAL_EXECUTABLE=aurora-echo
 BUILD_DIR=build
+VIRTUALENV=$(BUILD_DIR)/_virtualenv
+VIRTUALENV_BIN=$(VIRTUALENV)/bin
+ACTIVATE=$(VIRTUALENV_BIN)/activate
 PYTHON_INTERPRETER=python3
 
-.PHONY: all clean build
+.PHONY: all clean build lint
 
 all: clean build
 
@@ -13,18 +16,21 @@ clean:
 	@rm -rf $(BUILD_DIR)
 	@echo "Build directory removed."
 
-build: build/_virtualenv
-	@rm -f $(BUILD_DIR)/$(FINAL_EXECUTABLE)
-	@sh -c '. $(BUILD_DIR)/_virtualenv/bin/activate; $(PYTHON_INTERPRETER) eggsecute.py $(PYTHON_MAIN) $(BUILD_DIR)/$(FINAL_EXECUTABLE)'
-	@chmod a+x $(BUILD_DIR)/$(FINAL_EXECUTABLE)
-	@echo "Package created."
+build: $(ACTIVATE)
+	rm -f $(BUILD_DIR)/$(FINAL_EXECUTABLE)
+	$(VIRTUALENV_BIN)/python eggsecute.py $(PYTHON_MAIN) $(BUILD_DIR)/$(FINAL_EXECUTABLE)
+	chmod a+x $(BUILD_DIR)/$(FINAL_EXECUTABLE)
+	echo "Package created."
 
-build/_virtualenv:
+lint: $(ACTIVATE)
+	$(VIRTUALENV_BIN)/python setup.py flake8
+
+$(VIRTUALENV) $(ACTIVATE) :
 	@command -v virtualenv >/dev/null 2>&1 || { echo >&2 "This build requires virtualenv to be installed.  Aborting."; exit 1; }
 	@mkdir -p $(BUILD_DIR)
-	@if [ -d $(BUILD_DIR)/_virtualenv ]; then \
+	@if [ -d $(VIRTUALENV) ]; then \
 		echo "Existing virtualenv found. Skipping virtualenv creation."; \
 	else \
-		virtualenv -p `which $(PYTHON_INTERPRETER)` $(BUILD_DIR)/_virtualenv; \
-		sh -c '. $(BUILD_DIR)/_virtualenv/bin/activate; pip install .'; \
+		virtualenv -p `which $(PYTHON_INTERPRETER)` $(VIRTUALENV); \
+		. $(ACTIVATE); pip install .; \
 	fi

--- a/aurora_echo/__init__.py
+++ b/aurora_echo/__init__.py
@@ -21,8 +21,8 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 ##
-import aurora_echo.boto_monkey
-from aurora_echo import echo_clone, echo_new, echo_modify, echo_promote, echo_retire
+import aurora_echo.boto_monkey  # noqa: F401
+from aurora_echo import echo_clone, echo_new, echo_modify, echo_promote, echo_retire  # noqa: F401
 from aurora_echo.entry import root
 
 

--- a/aurora_echo/boto_monkey.py
+++ b/aurora_echo/boto_monkey.py
@@ -1,22 +1,22 @@
-## Copyright 2016 Ray Holder
 ##
-## Licensed under the Apache License, Version 2.0 (the "License");
-## you may not use this file except in compliance with the License.
-## You may obtain a copy of the License at
+# Copyright 2016 Ray Holder
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 ##
-## http://www.apache.org/licenses/LICENSE-2.0
-##
-## Unless required by applicable law or agreed to in writing, software
-## distributed under the License is distributed on an "AS IS" BASIS,
-## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-## See the License for the specific language governing permissions and
-## limitations under the License.
 
 import atexit
-import codecs
 import json
 import os
-import sys
 import tempfile
 import zipfile
 
@@ -32,7 +32,7 @@ try:
     EGG_DIRS = set([os.path.split(x)[0] for x in EGG.namelist() if '/' in x])
     EGG_API_PATHS = [x for x in EGG_DIRS if 'botocore/data/' in x]
     EGG_API_PATHS.extend([x for x in EGG_DIRS if 'boto3/data/' in x])
-except:
+except Exception:
     pass
 
 
@@ -55,7 +55,6 @@ class JSONFileLoader2(object):
         """
         # TODO fix? seems inconsistent with .format usage pattern. Also cast as str?
         return any(x.startswith("%s" % file_path) for x in EGG.namelist())
-
 
     def load_file(self, file_path: str):
         """Attempt to load the file path.
@@ -148,7 +147,7 @@ def list_api_versions(self, service_name: str, type_name: str):
                 if self.file_loader.exists(full_path):
                     known_api_versions.add(api_version[1])
     if not known_api_versions:
-        #raise Exception('service_name: {0}, type_name: {1}'.format(service_name, type_name))
+        # raise Exception('service_name: {0}, type_name: {1}'.format(service_name, type_name))
         raise DataNotFoundError(data_path=service_name)
     return sorted(known_api_versions)
 

--- a/aurora_echo/echo_clone.py
+++ b/aurora_echo/echo_clone.py
@@ -40,7 +40,7 @@ log_prefix = log_prefix_factory(ECHO_CLONE_COMMAND)
 
 
 def collect_clone_params(source_cluster_name: str, new_cluster_name: str, db_subnet_group_name: str,
-                           vpc_security_group_id: list, tags: list):
+                         vpc_security_group_id: list, tags: list):
     """
     Convert parameters into a dict of known values appropriate to be used in an RDS API call.
 
@@ -133,7 +133,7 @@ def create_clone_cluster_and_instance(clone_params: dict, instance_params: dict,
 @click.option('--minimum-age-hours', '-h', default=20)
 @click.option('--interactive', '-i', default=True, type=bool)
 def clone(aws_account_number: str, region: str, source_cluster_name: str, managed_name: str, db_subnet_group_name: str, db_instance_class: str,
-        engine: str, availability_zone: str, vpc_security_group_id: list, tag: list, minimum_age_hours: int, interactive: bool):
+          engine: str, availability_zone: str, vpc_security_group_id: list, tag: list, minimum_age_hours: int, interactive: bool):
     click.echo('{} Starting aurora-echo for {}'.format(log_prefix(), managed_name))
     util = EchoUtil(region, aws_account_number)
     if not util.instance_too_new(managed_name, minimum_age_hours):

--- a/aurora_echo/echo_modify.py
+++ b/aurora_echo/echo_modify.py
@@ -69,11 +69,10 @@ def modify_iam(cluster_identifier: str, iam_role_names: tuple, interactive: bool
         click.echo('{} Adding IAM to cluster...'.format(log_prefix()))
 
         for iam_role_arn in iam_role_arn_list:
-            iam_response = rds.add_role_to_db_cluster(DBClusterIdentifier=cluster_identifier, RoleArn=iam_role_arn)
+            rds.add_role_to_db_cluster(DBClusterIdentifier=cluster_identifier, RoleArn=iam_role_arn)
     else:
         # even if they didn't want an IAM added, it still successfully passed through this stage
         click.echo('{} No IAM roles provided. Nothing to do! {}'.format(log_prefix(), cluster_identifier))
-
 
 
 @root.command()

--- a/aurora_echo/echo_new.py
+++ b/aurora_echo/echo_new.py
@@ -81,7 +81,6 @@ def collect_cluster_params(cluster_snapshot_identifier: str, new_cluster_name: s
     # Our tags indicating the instance is managed, plus optional user-defined tags
     params['Tags'] = tags  # a list of dicts
 
-
     return params
 
 

--- a/aurora_echo/echo_promote.py
+++ b/aurora_echo/echo_promote.py
@@ -87,7 +87,7 @@ def update_dns(hosted_zone_ids: tuple, record_set_name: str, cluster_endpoint: s
             click.confirm('{} Ready to update DNS record with these settings?'.format(log_prefix()), abort=True)  # exits entirely if no
 
         # update to the found instance endpoint
-        response = route53.change_resource_record_sets(**params)
+        route53.change_resource_record_sets(**params)
         click.echo('{} Success! DNS updated in hosted zone {}'.format(log_prefix(), hosted_zone))
 
 

--- a/aurora_echo/echo_retire.py
+++ b/aurora_echo/echo_retire.py
@@ -42,13 +42,13 @@ def delete_instance(instance: dict, interactive: bool):
         'DBInstanceIdentifier': instance_identifier,
         'SkipFinalSnapshot': True,
     }
-    
+
     cluster_identifier = instance['DBClusterIdentifier']
     cluster_params = {
         'DBClusterIdentifier': cluster_identifier,
         'SkipFinalSnapshot': True,
     }
-    
+
     click.echo('{} Parameters:'.format(log_prefix()))
     click.echo(json.dumps(instance_params, indent=4, sort_keys=True))
     click.echo(json.dumps(cluster_params, indent=4, sort_keys=True))
@@ -58,8 +58,8 @@ def delete_instance(instance: dict, interactive: bool):
                       'along with ALL AUTOMATED BACKUPS?'.format(log_prefix()), abort=True)  # exits entirely if no
 
     # delete the instance first so the cluster is empty, otherwise it'll fail
-    response = rds.delete_db_instance(**instance_params)
-    response = rds.delete_db_cluster(**cluster_params)
+    rds.delete_db_instance(**instance_params)
+    rds.delete_db_cluster(**cluster_params)
 
 
 @root.command()

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,9 @@
 from setuptools import setup, find_packages
 
+setup_requirements = [
+    'flake8==3.5.0'
+]
+
 with open('requirements.txt') as file_requirements:
     requirements = file_requirements.read().splitlines()
 
@@ -8,6 +12,7 @@ setup(
     version='2.0.1',
     packages=find_packages(),
     install_requires=requirements,
+    setup_requires=setup_requirements,
     entry_points='''
         [console_scripts]
         aurora_echo=aurora_echo:main


### PR DESCRIPTION
- Create linting target
- Make linting changes to get the linting target to pass
- Use the full path to the virtualenv's `python` executable instead of calling `sh`

<Details>

```
↪ make clean
Project .pyc's removed.
Build directory removed.

↪ make lint
Running virtualenv with interpreter /usr/bin/python3
Using base prefix '/usr'
New python executable in /home/whw/Dev/aurora-echo/build/_virtualenv/bin/python3
Also creating executable in /home/whw/Dev/aurora-echo/build/_virtualenv/bin/python
Installing setuptools, pip, wheel...done.
Looking in indexes: https://nexus.blacklocus.com/repository/pypi/simple
Processing /home/whw/Dev/aurora-echo
Collecting boto3==1.4.4 (from aurora-echo==2.0.1)
  Using cached https://nexus.blacklocus.com/repository/pypi/packages/91/60/649da03299624f524c8d0cd4c6c73c194023e85dd4938f1e7712ab6888bf/boto3-1.4.4-py2.py3-none-any.whl
Collecting botocore==1.5.80 (from aurora-echo==2.0.1)
  Using cached https://nexus.blacklocus.com/repository/pypi/packages/54/06/b9999e1b7f9cbdf687fbe53a0df7a54968a87e8ed1ef9ef20f3d195c82a7/botocore-1.5.80-py2.py3-none-any.whl
Collecting certifi==2015.4.28 (from aurora-echo==2.0.1)
  Using cached https://nexus.blacklocus.com/repository/pypi/packages/86/35/9758a67004a266047c779ae40a3d937869bfc6fc3422f6c606b8afbc9d23/certifi-2015.04.28-py2.py3-none-any.whl
Collecting click==6.6 (from aurora-echo==2.0.1)
  Using cached https://nexus.blacklocus.com/repository/pypi/packages/1c/7c/10b4132dd952b6a04e37626258825b8aa8c1eb99545f2eb26a77c21efb55/click-6.6-py2.py3-none-any.whl
Collecting jmespath<1.0.0,>=0.7.1 (from boto3==1.4.4->aurora-echo==2.0.1)
  Using cached https://nexus.blacklocus.com/repository/pypi/packages/b7/31/05c8d001f7f87f0f07289a5fc0fc3832e9a57f2dbd4d3b0fee70e0d51365/jmespath-0.9.3-py2.py3-none-any.whl
Collecting s3transfer<0.2.0,>=0.1.10 (from boto3==1.4.4->aurora-echo==2.0.1)
  Using cached https://nexus.blacklocus.com/repository/pypi/packages/d7/14/2a0004d487464d120c9fb85313a75cd3d71a7506955be458eebfe19a6b1d/s3transfer-0.1.13-py2.py3-none-any.whl
Collecting python-dateutil<3.0.0,>=2.1 (from botocore==1.5.80->aurora-echo==2.0.1)
  Using cached https://nexus.blacklocus.com/repository/pypi/packages/cf/f5/af2b09c957ace60dcfac112b669c45c8c97e32f94aa8b56da4c6d1682825/python_dateutil-2.7.3-py2.py3-none-any.whl
Collecting docutils>=0.10 (from botocore==1.5.80->aurora-echo==2.0.1)
  Using cached https://nexus.blacklocus.com/repository/pypi/packages/36/fa/08e9e6e0e3cbd1d362c3bbee8d01d0aedb2155c4ac112b19ef3cae8eed8d/docutils-0.14-py3-none-any.whl
Collecting six>=1.5 (from python-dateutil<3.0.0,>=2.1->botocore==1.5.80->aurora-echo==2.0.1)
  Using cached https://nexus.blacklocus.com/repository/pypi/packages/67/4b/141a581104b1f6397bfa78ac9d43d8ad29a7ca43ea90a2d863fe3056e86a/six-1.11.0-py2.py3-none-any.whl
Building wheels for collected packages: aurora-echo
  Running setup.py bdist_wheel for aurora-echo ... done
  Stored in directory: /home/whw/.cache/pip/wheels/85/64/41/55b8937bc144f8985d02a0174123cfd9913a60178a03b5fa15
Successfully built aurora-echo
Installing collected packages: jmespath, six, python-dateutil, docutils, botocore, s3transfer, boto3, certifi, click, aurora-echo
Successfully installed aurora-echo-2.0.1 boto3-1.4.4 botocore-1.5.80 certifi-2015.4.28 click-6.6 docutils-0.14 jmespath-0.9.3 python-dateutil-2.7.3 s3transfer-0.1.13 six-1.11.0
build/_virtualenv/bin/python setup.py flake8
running flake8


↪ make build
rm -f build/aurora-echo
build/_virtualenv/bin/python eggsecute.py aurora_echo/__init__.py build/aurora-echo
chmod a+x build/aurora-echo
echo "Package created."
Package created.


↪ ./build/aurora-echo --help
Usage: aurora-echo [OPTIONS] COMMAND [ARGS]...

Options:
  --help  Show this message and exit.

Commands:
  clone
  modify
  new
  promote
  retire

↪ ./build/aurora-echo clone REDACTED -- it worked
```

</Details>