### PR TITLE
update type hint to match click option definition for minimum-age-hours

### DIFF
--- a/aurora_echo/echo_clone.py
+++ b/aurora_echo/echo_clone.py
@@ -139,7 +139,7 @@ def create_clone_cluster_and_instance(clone_params: dict, instance_params: dict,
 @click.option('--db-parameter-group-name', '-pgn')
 @click.option('--suffix', '-sf', default=None)
 def clone(aws_account_number: str, region: str, source_cluster_name: str, managed_name: str, db_subnet_group_name: str, db_instance_class: str,
-          engine: str, availability_zone: str, vpc_security_group_id: list, tag: list, minimum_age_hours: int, interactive: bool, db_parameter_group_name: str, suffix: str):
+          engine: str, availability_zone: str, vpc_security_group_id: list, tag: list, minimum_age_hours: float, interactive: bool, db_parameter_group_name: str, suffix: str):
     click.echo('{} Starting aurora-echo for {}'.format(log_prefix(), managed_name))
     util = EchoUtil(region, aws_account_number)
     if not util.instance_too_new(managed_name, minimum_age_hours):

--- a/aurora_echo/echo_new.py
+++ b/aurora_echo/echo_new.py
@@ -145,7 +145,7 @@ def create_cluster_and_instance(cluster_params: dict, instance_params: dict, int
 @click.option('--interactive', '-i', default=True, type=bool)
 @click.option('--suffix', '-sf', default=None)
 def new(aws_account_number: str, region: str, cluster_snapshot_name: str, managed_name: str, db_subnet_group_name: str, db_instance_class: str,
-        engine: str, availability_zone: str, vpc_security_group_id: list, tag: list, minimum_age_hours: int, interactive: bool, suffix: str):
+        engine: str, availability_zone: str, vpc_security_group_id: list, tag: list, minimum_age_hours: float, interactive: bool, suffix: str):
     click.echo('{} Starting aurora-echo for {}'.format(log_prefix(), managed_name))
     util = EchoUtil(region, aws_account_number)
     if not util.instance_too_new(managed_name, minimum_age_hours):


### PR DESCRIPTION
Just noticed that I did not update the type hints for minimum-age-hours when I submitted PR #13, so this updates them to match the definition in the click.option() call.